### PR TITLE
 fixed words boundaries interpolation

### DIFF
--- a/lib/align/index.js
+++ b/lib/align/index.js
@@ -34,6 +34,30 @@ function interpolationOptimization(wordsList){
     });
 }
 
+// after the interpolation, some words have overlapping timecodes.
+// the end time of the previous word is greater then the start of the current word
+// altho negligible when using in a transcript editor context
+// we want to avoid this, coz it causes issues when using the time of the words to generate
+// auto segmented captions. As it results in sentence
+// boundaries overlapping on screen during playback
+function adjustTimecodesBoundaries(words) {
+
+    return words.map((word, index, arr) => {
+      // excluding first element
+      if (index != 0 ) {
+        const previousWord = arr[index - 1];
+        const currentWord = word;
+        if (previousWord.end > currentWord.start) {
+          word.start = previousWord.end;
+        }
+  
+        return word;
+      }
+  
+      return word;
+    });
+  }
+
 function interpolate(wordsList){
     let words = interpolationOptimization(wordsList)
     const indicies = [...Array(words.length).keys()];
@@ -67,7 +91,7 @@ function interpolate(wordsList){
         }
         return word;
     })
-    return words;
+    return adjustTimecodesBoundaries(words);
 }
 
 function alignRefTextWithSTT(opCodes, sttWords, transcriptWords){


### PR DESCRIPTION
STT output 

```js
{
      "id": 43,
      "start": 17.41,
      "end": 17.63,
      "text": "this,"
    },
    {
      "id": 44,
      "start": 17.63,
      "end": 17.77,
      "text": "they're"
    },
    {
      "id": 45,
      "start": 17.77,
      "end": 17.91,
      "text": "gonna"
    },
    {
      "id": 46,
      "start": 17.91,
      "end": 18.01,
      "text": "be"
    },
```


aligned - time-codes of word overlap

```js
  {
    "start": 17.4,
    "end": 17.63,
    "word": "this,"
  },
  {
    "word": "there",
    "start": 17.502,
    "end": 17.706
  },
  {
    "word": "are",
    "start": 17.604,
    "end": 17.782
  },
  {
    "word": "going",
    "start": 17.706,
    "end": 17.858
  },
  {
    "word": "to",
    "start": 17.808,
    "end": 17.934
  },
  {
    "end": 18.01,
    "start": 17.91,
    "word": "be"
  },
```
Added an `adjustTimecodesBoundaries` to `interpolate` to readjust word time boundaries and remove overlap

```js
// after the interpolation, some words have overlapping timecodes.
// the end time of the previous word is greater then the start of the current word
// altho negligible when using in a transcript editor context
// we want to avoid this, coz it causes issues when using the time of the words to generate
// auto segmented captions. As it results in sentence
// boundaries overlapping on screen during playback
function adjustTimecodesBoundaries(words) {

    return words.map((word, index, arr) => {
      // excluding first element
      if (index != 0 ) {
        const previousWord = arr[index - 1];
        const currentWord = word;
        if (previousWord.end > currentWord.start) {
          word.start = previousWord.end;
        }
  
        return word;
      }
  
      return word;
    });
  }
```